### PR TITLE
Add GPU job pressure monitoring

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -12,6 +12,10 @@ HTCondor collector
     → gpu_state_YYYY-MM.db (SQLite, one file per calendar month)
     → usage_stats.py (via emailer.sh)
     → email report
+
+HTCondor schedds (all)
+    → get_job_pressure.py (every 5 min)
+    → job_pressure_YYYY-MM.db (SQLite, one file per calendar month)
 ```
 
 ## Crontab entries
@@ -19,6 +23,7 @@ HTCondor collector
 ```
 # Data collection
 */5 * * * * /home/iaross/gpureports/.venv/bin/python /home/iaross/gpureports/get_gpu_state.py &> /tmp/gpu_state.log
+*/5 * * * * /home/iaross/gpureports/.venv/bin/python /home/iaross/gpureports/get_job_pressure.py &> /tmp/job_pressure.log
 
 # Email reports
 0 6 * * *    bash /home/iaross/gpureports/emailer.sh daily   &> /tmp/gpu_emailer.log
@@ -33,7 +38,8 @@ To install: `crontab -e` on the production host and paste the above.
 
 | Log | Written by |
 |-----|-----------|
-| `/tmp/gpu_state.log` | `get_gpu_state.py` — data collection |
+| `/tmp/gpu_state.log` | `get_gpu_state.py` — GPU slot collection |
+| `/tmp/job_pressure.log` | `get_job_pressure.py` — idle GPU job collection |
 | `/tmp/gpu_emailer.log` | `emailer.sh daily` and `emailer.sh test` |
 | `/tmp/gpu_emailer_weekly.log` | `emailer.sh weekly` |
 | `/tmp/gpu_emailer_monthly.log` | `emailer.sh monthly` |
@@ -46,10 +52,11 @@ SQLite databases live in the repo directory at `/home/iaross/gpureports/`:
 gpu_state_2025-06.db
 gpu_state_2025-07.db
 ...
-gpu_state_YYYY-MM.db   ← one per calendar month, created automatically
+gpu_state_YYYY-MM.db      ← GPU slot state, one per calendar month
+job_pressure_YYYY-MM.db   ← idle GPU job queue snapshots, one per calendar month
 ```
 
-`get_gpu_state.py` creates a new file on the first run of each month.
+Both scripts create a new file on the first run of each month.
 
 ## Changing email recipients
 
@@ -82,10 +89,14 @@ bash emailer.sh daily    # or weekly / monthly / test
 - Verify `get_gpu_state.py` cron is running: `crontab -l`
 - Check disk space: `df -h /home/iaross/gpureports`
 
-**`get_gpu_state.py` exits silently**
-- The script uses HTCondor Python bindings (`htcondor` package) which must be installed
+**`get_gpu_state.py` or `get_job_pressure.py` exits silently**
+- The scripts use HTCondor Python bindings (`htcondor` package) which must be installed
   in the system Python or the venv. These are not in `pyproject.toml` because they're
   provided by the HTCondor installation on the host — not installable via pip on dev machines.
+
+**`get_job_pressure.py` reports 0 jobs unexpectedly**
+- Check `/tmp/job_pressure.log` for per-schedd query warnings
+- Confirm schedd discovery works: `python -c "import htcondor; c=htcondor.Collector('cm.chtc.wisc.edu'); print(len(c.locateAll(htcondor.DaemonTypes.Schedd)), 'schedds found')"`
 
 ## Dependencies
 

--- a/analyze_pool_health.py
+++ b/analyze_pool_health.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""
+Pool health analysis: detect mismatches between open-capacity slot availability
+and job wait times.
+
+Core signal: if open-capacity slots are sitting Unclaimed while single-GPU jobs
+are waiting a long time, something is misconfigured (job requirements don't match
+available slots, or machines have configuration preventing matches).
+
+Usage:
+    python analyze_pool_health.py
+    python analyze_pool_health.py --csv my_dump.csv --db gpu_state_2026-04.db
+    python analyze_pool_health.py --start 2026-04-01 --end 2026-04-15
+"""
+
+import argparse
+import sqlite3
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import pandas as pd
+
+ROLLING_WINDOW = "12h"
+BASELINE_DAYS = 14
+MIN_WAIT_S = 1
+CAP_WAIT_H = 48
+MIN_PERIODS = 5
+WAIT_SPIKE_RATIO = 2.0
+BURST_JOBS_PER_HOUR = 500
+
+# Rolling correlation between open_unclaimed and rolling-median wait time.
+# A sustained positive correlation (idle slots rising WITH wait time) is the
+# early-warning signal that normal supply/demand is inverted.
+CORR_WINDOW_H = 24  # hours of data per correlation estimate
+CORR_MIN_PERIODS = 8  # minimum non-NaN pairs within the window
+CORR_FLIP_MIN_H = 4  # minimum consecutive positive-correlation hours to report
+
+
+# ── Slot metrics ─────────────────────────────────────────────────────────────
+
+
+def load_slot_metrics(db_path: str, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame:
+    """
+    Hourly open-capacity unclaimed slot counts using per-snapshot GPU UUID deduplication.
+
+    Matches usage_stats methodology: for each sampled timestamp, deduplicate GPU UUIDs
+    by preferring primary-claimed (3) > primary-unclaimed (2) > backfill-claimed (1),
+    then count unique unclaimed open-capacity GPUs per snapshot and average per hour.
+    This avoids double-counting GPUs that appear in both primary and backfill slot rows.
+    """
+    start_str = start.strftime("%Y-%m-%d %H:%M:%S")
+    end_str = end.strftime("%Y-%m-%d %H:%M:%S")
+    conn = sqlite3.connect(db_path)
+    df = pd.read_sql(
+        f"""
+        WITH ranked AS (
+            SELECT
+                timestamp,
+                AssignedGPUs,
+                State,
+                Name,
+                PrioritizedProjects,
+                ROW_NUMBER() OVER (
+                    PARTITION BY timestamp, AssignedGPUs
+                    ORDER BY
+                        CASE
+                            WHEN State='Claimed'   AND Name NOT LIKE '%backfill%' THEN 3
+                            WHEN State='Unclaimed' AND Name NOT LIKE '%backfill%' THEN 2
+                            WHEN State='Claimed'   AND Name     LIKE '%backfill%' THEN 1
+                            ELSE 0
+                        END DESC
+                ) AS rn
+            FROM gpu_state
+            WHERE AssignedGPUs IS NOT NULL
+              AND AssignedGPUs != ''
+              AND timestamp >= '{start_str}'
+              AND timestamp <= '{end_str}'
+        ),
+        deduped AS (
+            SELECT timestamp, AssignedGPUs, State, Name, PrioritizedProjects
+            FROM ranked
+            WHERE rn = 1
+        ),
+        open_cap AS (
+            -- Open-capacity primary slots: no PrioritizedProjects, not backfill
+            SELECT timestamp, AssignedGPUs, State
+            FROM deduped
+            WHERE (PrioritizedProjects IS NULL OR PrioritizedProjects = '')
+              AND Name NOT LIKE '%backfill%'
+        ),
+        per_snapshot AS (
+            SELECT
+                timestamp,
+                strftime('%Y-%m-%d %H:00', timestamp) AS hour,
+                COUNT(DISTINCT CASE WHEN State = 'Unclaimed' THEN AssignedGPUs END)
+                    AS unclaimed_gpus,
+                COUNT(DISTINCT CASE WHEN State = 'Claimed'   THEN AssignedGPUs END)
+                    AS claimed_gpus
+            FROM open_cap
+            GROUP BY timestamp
+        )
+        SELECT
+            hour,
+            AVG(unclaimed_gpus) AS open_unclaimed,
+            AVG(claimed_gpus)   AS open_claimed,
+            COUNT(*)            AS sample_count
+        FROM per_snapshot
+        GROUP BY hour
+        ORDER BY hour
+        """,
+        conn,
+    )
+    conn.close()
+
+    df["hour"] = pd.to_datetime(df["hour"])
+    df = df.set_index("hour").sort_index()
+    return df.loc[start:end]
+
+
+# ── Job metrics ───────────────────────────────────────────────────────────────
+
+
+def load_jobs(csv_path: str, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame:
+    cols = ["QDate", "JobCurrentStartDate", "initialwaitduration", "RequestGpus", "Owner"]
+    df = pd.read_csv(csv_path, usecols=cols, low_memory=False)
+    df["submitted_at"] = pd.to_datetime(df["QDate"], unit="s")
+    # Anchor wait-time trend on start date: aligns with when the pool state
+    # actually caused the delay, and avoids burst-submission spikes collapsing
+    # many long-wait jobs onto a single submission timestamp.
+    df["started_at"] = pd.to_datetime(df["JobCurrentStartDate"], unit="s")
+    df = df[(df["RequestGpus"] == 1) & (df["initialwaitduration"] >= MIN_WAIT_S) & df["started_at"].notna()]
+    df["wait_h"] = df["initialwaitduration"] / 3600
+    df = df[df["wait_h"] <= CAP_WAIT_H]
+    return df[df["started_at"].between(start, end)].copy()
+
+
+def rolling_wait_stats(jobs: pd.DataFrame) -> pd.DataFrame:
+    ts = jobs.set_index("started_at").sort_index()["wait_h"]
+    if ts.empty:
+        return pd.DataFrame(columns=["rolling_median", "baseline", "ratio"])
+
+    grid = pd.date_range(ts.index.min().floor("30min"), ts.index.max().ceil("30min"), freq="30min")
+    window_td = pd.Timedelta(ROLLING_WINDOW)
+    medians = pd.Series(index=grid, dtype=float)
+    for t in grid:
+        w = ts[(ts.index >= t - window_td) & (ts.index < t)]
+        if len(w) >= MIN_PERIODS:
+            medians[t] = w.median()
+
+    stats = pd.DataFrame({"rolling_median": medians})
+    daily = ts.resample("1D").median().dropna()
+    baseline = daily.rolling(BASELINE_DAYS, min_periods=3).median()
+    stats["baseline"] = baseline.reindex(stats.index, method="ffill")
+    stats["ratio"] = stats["rolling_median"] / stats["baseline"]
+    return stats
+
+
+# ── Mismatch detection ────────────────────────────────────────────────────────
+
+
+def detect_mismatch_periods(
+    slots: pd.DataFrame,
+    wait_stats: pd.DataFrame,
+    baseline_days: int = 5,
+) -> pd.DatetimeIndex:
+    """
+    Return timestamps where open-capacity unclaimed slots are anomalously high
+    AND wait times are elevated.
+
+    "Anomalously high" is defined relative to a stable early-window baseline
+    (first baseline_days of data) rather than a rolling mean, so sustained
+    elevated periods don't get normalised away.  The threshold is
+    baseline_mean + 1.5 * baseline_std.
+    """
+    oc = slots["open_unclaimed"].resample("1h").mean()
+
+    baseline_end = oc.index[0] + pd.Timedelta(days=baseline_days)
+    baseline = oc.loc[:baseline_end]
+    threshold = baseline.mean() + 1.0 * baseline.std()
+
+    ratio_hourly = wait_stats["ratio"].resample("1h").max()
+
+    idx = oc.index.intersection(ratio_hourly.index)
+    mismatch = (oc.loc[idx] > threshold) & (ratio_hourly.loc[idx] > WAIT_SPIKE_RATIO)
+    return mismatch[mismatch].index
+
+
+def detect_bursts(jobs: pd.DataFrame) -> list[dict]:
+    hourly = (
+        jobs.set_index("submitted_at")
+        .resample("1h")
+        .agg(
+            count=("wait_h", "size"),
+            top_owner=("Owner", lambda x: x.value_counts().index[0] if len(x) else ""),
+        )
+    )
+    bursts = hourly[hourly["count"] > BURST_JOBS_PER_HOUR]
+    if bursts.empty:
+        return []
+    gaps = bursts.index.to_series().diff() > pd.Timedelta("6h")
+    new_ev = pd.concat([pd.Series([True]), gaps.iloc[1:]])
+    new_ev.index = bursts.index
+    return [
+        {"start": t, "jobs_per_hr": bursts.loc[t, "count"], "owner": bursts.loc[t, "top_owner"]}
+        for t in bursts.index[new_ev]
+    ]
+
+
+# ── Rolling correlation ───────────────────────────────────────────────────────
+
+
+def compute_rolling_corr(
+    slots: pd.DataFrame,
+    wait_stats: pd.DataFrame,
+    window_h: int = CORR_WINDOW_H,
+) -> pd.Series:
+    """
+    Hourly Pearson correlation between open_unclaimed and rolling-median wait time
+    over a sliding window.  NaN wait values (sparse overnight hours) are dropped
+    within each window; min_periods guards against windows that are too sparse.
+    """
+    oc = slots["open_unclaimed"].resample("1h").mean()
+    wait = wait_stats["rolling_median"].resample("1h").median()
+    combined = pd.DataFrame({"oc": oc, "wait": wait})
+    return combined["oc"].rolling(window=window_h, min_periods=CORR_MIN_PERIODS).corr(combined["wait"])
+
+
+def detect_corr_flip_events(rolling_corr: pd.Series) -> list[dict]:
+    """
+    Return each run of consecutive hours where rolling correlation is positive,
+    provided the run lasts at least CORR_FLIP_MIN_H hours.
+    """
+    positive = (rolling_corr > 0).fillna(False)
+    events: list[dict] = []
+    in_run = False
+    run_start = None
+
+    for t, is_pos in positive.items():
+        if is_pos and not in_run:
+            in_run = True
+            run_start = t
+        elif not is_pos and in_run:
+            hours = int((t - run_start) / pd.Timedelta("1h"))
+            if hours >= CORR_FLIP_MIN_H:
+                events.append({"start": run_start, "end": t, "hours": hours})
+            in_run = False
+
+    if in_run:
+        t = rolling_corr.index[-1]
+        hours = int((t - run_start) / pd.Timedelta("1h")) + 1
+        if hours >= CORR_FLIP_MIN_H:
+            events.append({"start": run_start, "end": t, "hours": hours})
+
+    return events
+
+
+# ── Report ────────────────────────────────────────────────────────────────────
+
+
+def print_report(slots, wait_stats, mismatch_times, bursts, corr_flips) -> None:
+    oc_start = slots["open_unclaimed"].iloc[:24].mean()
+    oc_end = slots["open_unclaimed"].iloc[-24:].mean()
+
+    print("\n" + "=" * 68)
+    print("POOL HEALTH REPORT")
+    print("=" * 68)
+    print(f"\nOpen-capacity unclaimed (avg): " f"{oc_start:.0f} slots at start → {oc_end:.0f} at end")
+
+    if mismatch_times.empty:
+        print("\nNo mismatch periods detected.")
+    else:
+        # Collapse consecutive hours into events
+        gaps = mismatch_times.to_series().diff() > pd.Timedelta("2h")
+        new_ev = pd.concat([pd.Series([True]), gaps.iloc[1:]])
+        new_ev.index = mismatch_times
+        starts = mismatch_times[new_ev]
+
+        print("\nMISMATCH PERIODS — open slots unclaimed while jobs wait:")
+        for t in starts:
+            window = wait_stats.loc[t : t + pd.Timedelta("6h")].dropna()
+            peak_wait = window["rolling_median"].max() if not window.empty else float("nan")
+            peak_oc = slots["open_unclaimed"].loc[t : t + pd.Timedelta("6h")].max()
+            print(
+                f"  {t.strftime('%Y-%m-%d %H:%M')}  "
+                f"peak wait {peak_wait:.1f}h  "
+                f"open unclaimed {peak_oc:.0f} slots"
+            )
+
+    print(
+        f"\nCORRELATION FLIP EVENTS — oc/wait correlation positive for ≥{CORR_FLIP_MIN_H}h " f"(early-warning signal):"
+    )
+    if not corr_flips:
+        print("  None.")
+    for ev in corr_flips:
+        print(
+            f"  {ev['start'].strftime('%Y-%m-%d %H:%M')} → " f"{ev['end'].strftime('%Y-%m-%d %H:%M')}  ({ev['hours']}h)"
+        )
+
+    print(f"\nQUEUE BURSTS (>{BURST_JOBS_PER_HOUR} jobs/hr):")
+    if not bursts:
+        print("  None.")
+    for ev in bursts:
+        print(f"  {ev['start'].strftime('%Y-%m-%d %H:%M')}  " f"{ev['jobs_per_hr']:,}/hr  {ev['owner']}")
+
+
+# ── Plot ──────────────────────────────────────────────────────────────────────
+
+
+def plot(jobs, slots, wait_stats, mismatch_times, bursts, rolling_corr, output) -> None:
+    fig, (ax1, ax2, ax3, ax4) = plt.subplots(
+        4,
+        1,
+        figsize=(16, 13),
+        sharex=True,
+        gridspec_kw={"height_ratios": [3, 2, 1.5, 1.5]},
+    )
+
+    # ── wait time ─────────────────────────────────────────────────────────
+    ax1.plot(
+        wait_stats.index,
+        wait_stats["rolling_median"],
+        color="#2980b9",
+        lw=1.5,
+        label=f"{ROLLING_WINDOW} rolling median",
+    )
+    ax1.plot(
+        wait_stats.index,
+        wait_stats["baseline"],
+        color="#e67e22",
+        lw=1.8,
+        ls="-.",
+        label=f"{BASELINE_DAYS}-day rolling baseline",
+    )
+
+    elevated = wait_stats["ratio"] > WAIT_SPIKE_RATIO
+    if elevated.any():
+        ax1.scatter(
+            wait_stats.index[elevated],
+            wait_stats.loc[elevated, "rolling_median"],
+            color="#e74c3c",
+            zorder=5,
+            s=15,
+            label=f"Median > {WAIT_SPIKE_RATIO:.0f}× baseline",
+        )
+
+    # Shade mismatch periods
+    if not mismatch_times.empty:
+        gaps = mismatch_times.to_series().diff() > pd.Timedelta("2h")
+        new_ev = pd.concat([pd.Series([True]), gaps.iloc[1:]])
+        new_ev.index = mismatch_times
+        starts = mismatch_times[new_ev].to_list()
+        for i, t_start in enumerate(starts):
+            nxt = starts[i + 1] if i + 1 < len(starts) else t_start + pd.Timedelta("6h")
+            t_end = min(nxt, t_start + pd.Timedelta("6h"))
+            for ax in (ax1, ax2):
+                ax.axvspan(
+                    t_start,
+                    t_end,
+                    color="#e74c3c",
+                    alpha=0.12,
+                    label="Mismatch: open slots idle, jobs waiting" if i == 0 else None,
+                )
+
+    for ev in bursts:
+        ax1.axvline(
+            ev["start"],
+            color="#8e44ad",
+            ls=":",
+            lw=1.2,
+            alpha=0.7,
+            label=f"Burst >{BURST_JOBS_PER_HOUR}/hr" if ev == bursts[0] else None,
+        )
+
+    ax1.set_ylabel("Wait duration (hours)")
+    ax1.set_title("GPU Pool Health: Open-Capacity Slot Availability vs. Job Wait Time")
+    ax1.legend(loc="upper left", fontsize=8, ncol=2)
+    ax1.grid(True, alpha=0.3)
+    ax1.set_ylim(bottom=0)
+
+    # ── open capacity unclaimed ───────────────────────────────────────────
+    oc_hourly = slots["open_unclaimed"]
+    ax2.fill_between(oc_hourly.index, oc_hourly, color="#27ae60", alpha=0.3, label="Open-capacity unclaimed")
+    ax2.plot(oc_hourly.index, oc_hourly, color="#27ae60", lw=1.0)
+
+    # Rolling mean baseline for reference
+    roll_mean = oc_hourly.rolling("24h", min_periods=6).mean()
+    ax2.plot(roll_mean.index, roll_mean, color="#2c7a4b", lw=1.5, ls="--", alpha=0.8, label="24h rolling mean")
+
+    for ev in bursts:
+        ax2.axvline(ev["start"], color="#8e44ad", ls=":", lw=1.2, alpha=0.5)
+
+    ax2.set_ylabel("Open-capacity unclaimed slots")
+    ax2.set_ylim(bottom=0)
+    ax2.grid(True, alpha=0.3)
+    ax2.legend(loc="upper left", fontsize=8)
+
+    # ── jobs started per hour ─────────────────────────────────────────────
+    subs = jobs.set_index("started_at").resample("1h")["wait_h"].count()
+    ax3.bar(subs.index, subs.values, width=1 / 24, color="#7f8c8d", alpha=0.7)
+    for ev in bursts:
+        ax3.axvline(
+            ev["start"], color="#8e44ad", ls=":", lw=1.2, alpha=0.7, label=ev["owner"] if ev == bursts[0] else None
+        )
+
+    ax3.set_ylabel("Jobs started / hr")
+    ax3.grid(True, alpha=0.3)
+    if bursts:
+        ax3.legend(loc="upper left", fontsize=8)
+
+    # ── rolling oc/wait correlation ───────────────────────────────────────
+    ax4.plot(
+        rolling_corr.index,
+        rolling_corr,
+        color="#555555",
+        lw=1.2,
+        label=f"{CORR_WINDOW_H}h rolling correlation (oc vs wait)",
+    )
+    ax4.axhline(0, color="black", lw=0.8, ls="--")
+
+    # Shade positive (warning) and negative (normal) regions
+    ax4.fill_between(
+        rolling_corr.index,
+        rolling_corr,
+        0,
+        where=(rolling_corr > 0),
+        color="#e74c3c",
+        alpha=0.25,
+        label="Positive (inverted: warning)",
+    )
+    ax4.fill_between(
+        rolling_corr.index,
+        rolling_corr,
+        0,
+        where=(rolling_corr <= 0),
+        color="#27ae60",
+        alpha=0.15,
+        label="Negative (normal)",
+    )
+
+    ax4.set_ylabel("Pearson r")
+    ax4.set_xlabel("Date (job start time)")
+    ax4.set_ylim(-1, 1)
+    ax4.grid(True, alpha=0.3)
+    ax4.legend(loc="upper left", fontsize=8)
+
+    # x-axis
+    for ax in (ax1, ax2, ax3, ax4):
+        ax.set_xlim(jobs["started_at"].min(), jobs["started_at"].max())
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d"))
+        ax.xaxis.set_major_locator(mdates.DayLocator(interval=1))
+        plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha="right")
+
+    plt.tight_layout()
+    plt.savefig(output, dpi=150, bbox_inches="tight")
+    print(f"Plot saved to {output}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", default="elasticsearch_dump.csv")
+    parser.add_argument("--db", default="gpu_state_2026-04.db")
+    parser.add_argument("--output", default="pool_health_analysis.png")
+    parser.add_argument("--start", default=None)
+    parser.add_argument("--end", default=None)
+    args = parser.parse_args()
+
+    conn = sqlite3.connect(args.db)
+    db_start, db_end = conn.execute("SELECT MIN(timestamp), MAX(timestamp) FROM gpu_state").fetchone()
+    conn.close()
+    start = pd.Timestamp(args.start) if args.start else pd.Timestamp(db_start)
+    end = pd.Timestamp(args.end) if args.end else pd.Timestamp(db_end)
+
+    slots = load_slot_metrics(args.db, start, end)
+
+    # Load full CSV history so the 14-day baseline has data before the window.
+    # Wait trend is anchored on job start date; burst detection uses submit time.
+    all_jobs = load_jobs(args.csv, pd.Timestamp("2000-01-01"), pd.Timestamp("2099-01-01"))
+    wait_stats = rolling_wait_stats(all_jobs)
+    jobs = all_jobs[all_jobs["started_at"].between(start, end)]
+    wait_stats = wait_stats.loc[start:end]
+
+    # Burst detection needs the full submission-time picture, not filtered by start date
+    all_submit = pd.read_csv(
+        args.csv,
+        usecols=["QDate", "initialwaitduration", "RequestGpus", "Owner"],
+        low_memory=False,
+    )
+    all_submit["submitted_at"] = pd.to_datetime(all_submit["QDate"], unit="s")
+    all_submit["wait_h"] = all_submit["initialwaitduration"].fillna(0) / 3600
+    submit_window = all_submit[(all_submit["RequestGpus"] == 1) & all_submit["submitted_at"].between(start, end)]
+
+    mismatch_times = detect_mismatch_periods(slots, wait_stats)
+    bursts = detect_bursts(submit_window)
+    rolling_corr = compute_rolling_corr(slots, wait_stats)
+    corr_flips = detect_corr_flip_events(rolling_corr)
+
+    print_report(slots, wait_stats, mismatch_times, bursts, corr_flips)
+    plot(jobs, slots, wait_stats, mismatch_times, bursts, rolling_corr, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/get_gpu_state.py
+++ b/get_gpu_state.py
@@ -87,7 +87,8 @@ def collect_job_info(df: pd.DataFrame, db_path: str) -> None:
             Owner       TEXT,
             RequestGPUs REAL,
             QDate       INTEGER,
-            first_seen  TEXT
+            first_seen  TEXT,
+            InitialWaitDuration INTEGER
         )
     """)
     conn.commit()
@@ -118,7 +119,7 @@ def collect_job_info(df: pd.DataFrame, db_path: str) -> None:
 
         id_list = " || ".join(f'GlobalJobId == "{jid}"' for jid in batch_ids)
         constraint = f"({id_list})"
-        proj = ["GlobalJobId", "Cmd", "Arguments", "Owner", "RequestGPUs", "QDate"]
+        proj = ["GlobalJobId", "Cmd", "Arguments", "Owner", "RequestGPUs", "QDate", "InitialWaitDuration"]
 
         try:
             ads = schedd.query(constraint=constraint, projection=proj)
@@ -136,6 +137,7 @@ def collect_job_info(df: pd.DataFrame, db_path: str) -> None:
                     float(ad.get("RequestGPUs", 0) or 0),
                     int(ad.get("QDate", 0) or 0),
                     now_str,
+                    ad.get("InitialWaitDuration", ""),
                 )
             )
 
@@ -145,8 +147,8 @@ def collect_job_info(df: pd.DataFrame, db_path: str) -> None:
     conn = sqlite3.connect(db_path)
     conn.executemany(
         "INSERT OR IGNORE INTO job_info "
-        "(GlobalJobId, Cmd, Args, Owner, RequestGPUs, QDate, first_seen) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "(GlobalJobId, Cmd, Args, Owner, RequestGPUs, QDate, first_seen, InitialWaitDuration) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         rows,
     )
     conn.commit()

--- a/get_job_pressure.py
+++ b/get_job_pressure.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Periodic snapshot of idle GPU job pressure in the HTCondor pool.
+
+Queries all schedds for idle jobs requesting GPUs and records per-job
+resource requests in a monthly SQLite database.
+
+Crontab entry (on the production host):
+    */5 * * * * /home/iaross/gpureports/.venv/bin/python \
+        /home/iaross/gpureports/get_job_pressure.py &> /tmp/job_pressure.log
+"""
+
+import datetime
+import sqlite3
+
+import htcondor
+import typer
+
+COLL = htcondor.Collector("cm.chtc.wisc.edu")
+
+PROJ = [
+    "GlobalJobId",
+    "Owner",
+    "RequestGPUs",
+    "RequestCPUs",
+    "RequestMemory",
+    "RequestGPUMemory",
+    "QDate",
+]
+
+CONSTRAINT = "RequestGPUs >= 1 && JobStatus == 1"
+
+_CREATE_TABLE = """
+    CREATE TABLE IF NOT EXISTS job_pressure (
+        timestamp        TEXT,
+        GlobalJobId      TEXT,
+        ScheddName       TEXT,
+        Owner            TEXT,
+        RequestGPUs      REAL,
+        RequestCPUs      REAL,
+        RequestMemory    REAL,
+        RequestGPUMemory REAL,
+        QDate            INTEGER
+    )
+"""
+_CREATE_INDEX = "CREATE INDEX IF NOT EXISTS idx_timestamp ON job_pressure (timestamp)"
+
+
+def _float_or_none(val: object) -> float | None:
+    if val is None:
+        return None
+    try:
+        f = float(val)  # type: ignore[arg-type]
+        return f if f > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def collect_idle_gpu_jobs(timestamp: str) -> list[tuple]:
+    """Query all schedds for idle GPU jobs; return rows ready for DB insertion."""
+    try:
+        schedd_ads = COLL.locateAll(htcondor.DaemonTypes.Schedd)
+    except Exception as e:
+        print(f"Warning: could not query collector for schedds: {e}")
+        return []
+
+    rows: list[tuple] = []
+    for schedd_ad in schedd_ads:
+        schedd_name = schedd_ad.get("Name", "")
+        try:
+            schedd = htcondor.Schedd(schedd_ad)
+            ads = schedd.query(constraint=CONSTRAINT, projection=PROJ)
+        except Exception as e:
+            print(f"Warning: query failed for schedd {schedd_name}: {e}")
+            continue
+
+        for ad in ads:
+            rows.append(
+                (
+                    timestamp,
+                    ad.get("GlobalJobId", ""),
+                    schedd_name,
+                    ad.get("Owner", ""),
+                    float(ad.get("RequestGPUs", 0) or 0),
+                    float(ad.get("RequestCPUs", 0) or 0),
+                    float(ad.get("RequestMemory", 0) or 0),
+                    _float_or_none(ad.get("RequestGPUMemory")),
+                    int(ad.get("QDate", 0) or 0),
+                )
+            )
+
+    return rows
+
+
+def store_rows(rows: list[tuple], db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(_CREATE_TABLE)
+    conn.execute(_CREATE_INDEX)
+    conn.executemany("INSERT INTO job_pressure VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", rows)
+    conn.commit()
+    conn.close()
+
+
+def main(db_path: str = typer.Argument("/home/iaross/gpureports")) -> None:
+    timestamp = datetime.datetime.now().isoformat()
+    month = datetime.datetime.now().strftime("%Y-%m")
+    rows = collect_idle_gpu_jobs(timestamp)
+    print(f"{timestamp}: {len(rows)} idle GPU jobs")
+    if rows:
+        store_rows(rows, f"{db_path}/job_pressure_{month}.db")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/gpu_utils_polars.py
+++ b/gpu_utils_polars.py
@@ -155,13 +155,16 @@ def filter_df(df: pl.DataFrame, utilization: str = "", state: str = "", host: st
 
         # For duplicated GPUs, we want to keep the Claimed state and drop Unclaimed
         if duplicated_gpus.any():
-            # Create a rank column to sort out duplicates. Prefer claimed to unclaimed and primary slots to backfill.
+            # Create a rank column to sort out duplicates. Prefer primary slots over backfill,
+            # and claimed over unclaimed within the same type.
+            # Primary Unclaimed (rank 2) must beat Backfill Claimed (rank 1) so idle GPUs that
+            # are also offered as backfill are not dropped after the backfill filter.
             df = df.with_columns(
                 pl.when((pl.col("State") == "Claimed") & (~pl.col("Name").str.contains("backfill")))
                 .then(3)
-                .when((pl.col("State") == "Claimed") & (pl.col("Name").str.contains("backfill")))
-                .then(2)
                 .when((pl.col("State") == "Unclaimed") & (~pl.col("Name").str.contains("backfill")))
+                .then(2)
+                .when((pl.col("State") == "Claimed") & (pl.col("Name").str.contains("backfill")))
                 .then(1)
                 .otherwise(0)
                 .alias("_rank")
@@ -222,13 +225,16 @@ def filter_df(df: pl.DataFrame, utilization: str = "", state: str = "", host: st
 
         # For duplicated GPUs, we want to keep the Claimed state and drop Unclaimed
         if duplicated_gpus.any():
-            # Create a rank column to sort out duplicates. Prefer claimed to unclaimed and primary slots to backfill.
+            # Create a rank column to sort out duplicates. Prefer primary slots over backfill,
+            # and claimed over unclaimed within the same type.
+            # Primary Unclaimed (rank 2) must beat Backfill Claimed (rank 1) so idle GPUs that
+            # are also offered as backfill are not dropped after the backfill filter.
             df = df.with_columns(
                 pl.when((pl.col("State") == "Claimed") & (~pl.col("Name").str.contains("backfill")))
                 .then(3)
-                .when((pl.col("State") == "Claimed") & (pl.col("Name").str.contains("backfill")))
-                .then(2)
                 .when((pl.col("State") == "Unclaimed") & (~pl.col("Name").str.contains("backfill")))
+                .then(2)
+                .when((pl.col("State") == "Claimed") & (pl.col("Name").str.contains("backfill")))
                 .then(1)
                 .otherwise(0)
                 .alias("_rank")
@@ -506,13 +512,17 @@ def _apply_duplicate_cleanup(df: pl.DataFrame) -> pl.DataFrame:
     if not duplicated_gpus.any():
         return df
 
-    # Create a rank column to sort out duplicates
+    # Create a rank column to sort out duplicates.
+    # Prefer primary slots over backfill slots, and claimed over unclaimed within the same type.
+    # This matches the pandas version: Primary Claimed > Primary Unclaimed > Backfill Claimed > Backfill Unclaimed.
+    # IMPORTANT: Primary Unclaimed (rank 2) must beat Backfill Claimed (rank 1) so that idle GPUs
+    # that are also offered as backfill are not dropped from the denominator after the backfill filter.
     df = df.with_columns(
         pl.when((pl.col("State") == "Claimed") & (~pl.col("Name").str.contains("backfill")))
         .then(3)
-        .when((pl.col("State") == "Claimed") & (pl.col("Name").str.contains("backfill")))
-        .then(2)
         .when((pl.col("State") == "Unclaimed") & (~pl.col("Name").str.contains("backfill")))
+        .then(2)
+        .when((pl.col("State") == "Claimed") & (pl.col("Name").str.contains("backfill")))
         .then(1)
         .otherwise(0)
         .alias("_rank")

--- a/open_cap_user_jobs.py
+++ b/open_cap_user_jobs.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Open-capacity user job analysis: maximum number of jobs a single user has
+running on open-capacity slots per time slice.
+
+Open capacity = primary (non-backfill) slots with PrioritizedProjects empty.
+GPU UUIDs are deduplicated per snapshot using the same rank logic as usage_stats.
+
+Usage:
+    python open_cap_user_jobs.py
+    python open_cap_user_jobs.py --db gpu_state_2026-04.db --top-n 8
+    python open_cap_user_jobs.py --start 2026-04-10 --end 2026-04-15
+"""
+
+import argparse
+import sqlite3
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import pandas as pd
+
+RESAMPLE_FREQ = "15min"
+TOP_N_DEFAULT = 6
+
+
+def load_user_jobs(db_path: str, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame:
+    """
+    Per-snapshot count of claimed open-capacity GPUs per user, after dedup.
+    Returns a long-format DataFrame with columns: timestamp, user, jobs.
+    """
+    start_str = start.strftime("%Y-%m-%d %H:%M:%S")
+    end_str = end.strftime("%Y-%m-%d %H:%M:%S")
+    conn = sqlite3.connect(db_path)
+    df = pd.read_sql(
+        f"""
+        WITH ranked AS (
+            SELECT
+                timestamp, AssignedGPUs, State, Name, PrioritizedProjects, RemoteOwner,
+                ROW_NUMBER() OVER (
+                    PARTITION BY timestamp, AssignedGPUs
+                    ORDER BY CASE
+                        WHEN State='Claimed'   AND Name NOT LIKE '%backfill%' THEN 3
+                        WHEN State='Unclaimed' AND Name NOT LIKE '%backfill%' THEN 2
+                        WHEN State='Claimed'   AND Name     LIKE '%backfill%' THEN 1
+                        ELSE 0
+                    END DESC
+                ) AS rn
+            FROM gpu_state
+            WHERE AssignedGPUs IS NOT NULL AND AssignedGPUs != ''
+              AND timestamp >= '{start_str}' AND timestamp <= '{end_str}'
+        ),
+        deduped AS (
+            SELECT timestamp, AssignedGPUs, State, Name, PrioritizedProjects, RemoteOwner
+            FROM ranked WHERE rn = 1
+        ),
+        open_cap_claimed AS (
+            SELECT timestamp, RemoteOwner, AssignedGPUs
+            FROM deduped
+            WHERE (PrioritizedProjects IS NULL OR PrioritizedProjects = '')
+              AND Name NOT LIKE '%backfill%'
+              AND State = 'Claimed'
+              AND RemoteOwner IS NOT NULL AND RemoteOwner != ''
+        )
+        SELECT
+            timestamp,
+            RemoteOwner AS user,
+            COUNT(DISTINCT AssignedGPUs) AS jobs
+        FROM open_cap_claimed
+        GROUP BY timestamp, RemoteOwner
+        ORDER BY timestamp, jobs DESC
+        """,
+        conn,
+    )
+    conn.close()
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    # Strip domain suffix for cleaner labels
+    df["user"] = df["user"].str.replace(r"@.*", "", regex=True)
+    return df
+
+
+def resample_user_jobs(raw: pd.DataFrame, freq: str = RESAMPLE_FREQ) -> tuple[pd.DataFrame, pd.Series]:
+    """
+    Bucket raw snapshots into freq-wide windows.
+    Returns:
+        pivot  — wide DataFrame (index=bucket, columns=user, values=max jobs)
+        peak   — Series (index=bucket) of the single-user maximum per bucket
+    """
+    raw = raw.copy()
+    raw["bucket"] = raw["timestamp"].dt.floor(freq)
+    # Per bucket + user: take the max snapshot value within the window
+    bucketed = raw.groupby(["bucket", "user"])["jobs"].max().reset_index()
+    pivot = bucketed.pivot(index="bucket", columns="user", values="jobs").fillna(0)
+    peak = pivot.max(axis=1)
+    return pivot, peak
+
+
+def top_users_by_peak(pivot: pd.DataFrame, n: int) -> list[str]:
+    return pivot.max().nlargest(n).index.tolist()
+
+
+def print_summary(pivot: pd.DataFrame, peak: pd.Series, start: pd.Timestamp, end: pd.Timestamp) -> None:
+    top = pivot.max().sort_values(ascending=False)
+    # Approximate GPU-hours: each bucket is RESAMPLE_FREQ wide
+    bucket_hours = pd.Timedelta(RESAMPLE_FREQ).total_seconds() / 3600
+    gpu_hours = (pivot * bucket_hours).sum().sort_values(ascending=False)
+
+    print("\n" + "=" * 64)
+    print("OPEN-CAPACITY USER JOB SUMMARY")
+    print(f"{start.date()} → {end.date()}")
+    print("=" * 64)
+    print(f"\nOverall peak: {int(peak.max())} jobs by a single user" f"  ({peak.idxmax().strftime('%Y-%m-%d %H:%M')})")
+    print(f"\n{'User':<22} {'Peak jobs':>10} {'GPU-hours':>12}")
+    print("-" * 46)
+    for user in top.index[:15]:
+        print(f"  {user:<20} {int(top[user]):>10} {gpu_hours[user]:>12.0f}")
+
+
+def plot(
+    pivot: pd.DataFrame,
+    peak: pd.Series,
+    top_users: list[str],
+    output: str,
+) -> None:
+    fig, (ax1, ax2) = plt.subplots(
+        2,
+        1,
+        figsize=(16, 9),
+        sharex=True,
+        gridspec_kw={"height_ratios": [3, 1]},
+    )
+
+    colors = plt.cm.tab10.colors  # type: ignore[attr-defined]
+
+    # ── per-user lines ────────────────────────────────────────────────────
+    for i, user in enumerate(top_users):
+        if user not in pivot.columns:
+            continue
+        ax1.plot(pivot.index, pivot[user], color=colors[i % len(colors)], lw=1.0, alpha=0.75, label=user)
+
+    ax1.set_ylabel("GPUs running on open capacity")
+    ax1.set_title("Max single-user open-capacity GPU utilisation per 15-minute slice")
+    ax1.legend(loc="upper left", fontsize=8, ncol=2)
+    ax1.grid(True, alpha=0.3)
+    ax1.set_ylim(bottom=0)
+
+    # ── total claimed open-cap GPUs ───────────────────────────────────────
+    total = pivot.sum(axis=1)
+    ax2.fill_between(total.index, total.values, color="#7f8c8d", alpha=0.5, label="Total claimed open-cap GPUs")
+    ax2.plot(total.index, total.values, color="#7f8c8d", lw=0.8)
+    ax2.set_ylabel("Total")
+    ax2.set_xlabel("Time")
+    ax2.grid(True, alpha=0.3)
+    ax2.legend(loc="upper left", fontsize=8)
+    ax2.set_ylim(bottom=0)
+
+    for ax in (ax1, ax2):
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %d"))
+        ax.xaxis.set_major_locator(mdates.DayLocator(interval=1))
+        plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha="right")
+
+    plt.tight_layout()
+    plt.savefig(output, dpi=150, bbox_inches="tight")
+    print(f"\nPlot saved to {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", default="gpu_state_2026-04.db")
+    parser.add_argument("--output", default="open_cap_user_jobs.png")
+    parser.add_argument("--start", default=None)
+    parser.add_argument("--end", default=None)
+    parser.add_argument(
+        "--top-n", type=int, default=TOP_N_DEFAULT, help=f"Number of top users to plot (default: {TOP_N_DEFAULT})"
+    )
+    args = parser.parse_args()
+
+    conn = sqlite3.connect(args.db)
+    db_start, db_end = conn.execute("SELECT MIN(timestamp), MAX(timestamp) FROM gpu_state").fetchone()
+    conn.close()
+    start = pd.Timestamp(args.start) if args.start else pd.Timestamp(db_start)
+    end = pd.Timestamp(args.end) if args.end else pd.Timestamp(db_end)
+
+    raw = load_user_jobs(args.db, start, end)
+    pivot, peak = resample_user_jobs(raw)
+    top_users = top_users_by_peak(pivot, args.top_n)
+
+    print_summary(pivot, peak, start, end)
+    plot(pivot, peak, top_users, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plot_wait_time_trend.py
+++ b/plot_wait_time_trend.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Plot InitialWaitDuration trend over time to detect increases.
+
+Computes a rolling median over a configurable time window (default 6h) on
+single-GPU jobs, anchored to submission time (QDate), and overlays a 14-day
+rolling baseline median for comparison.
+
+Usage:
+    python plot_wait_time_trend.py
+    python plot_wait_time_trend.py --csv my_dump.csv --window 2h
+    python plot_wait_time_trend.py --window 12h --cap-hours 72
+"""
+
+import argparse
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import pandas as pd
+
+BASELINE_WINDOW_DAYS = 14
+MIN_WAIT_SECONDS = 1
+DEFAULT_CAP_HOURS = 48
+DEFAULT_WINDOW = "6h"
+MIN_PERIODS = 5  # minimum jobs in a rolling window to emit a value
+
+
+ANCHOR_COLS = {
+    "submit": "QDate",
+    "start": "JobCurrentStartDate",
+}
+ANCHOR_LABELS = {
+    "submit": "Submission time (QDate)",
+    "start": "Job start time (JobCurrentStartDate)",
+}
+
+
+def load_data(csv_path: str, cap_hours: float, anchor: str) -> pd.DataFrame:
+    time_col = ANCHOR_COLS[anchor]
+    cols = [time_col, "initialwaitduration", "RequestGpus"]
+    df = pd.read_csv(csv_path, usecols=cols, low_memory=False)
+    total = len(df)
+    df = df.dropna(subset=[time_col, "initialwaitduration"])
+    df = df[df["initialwaitduration"] >= MIN_WAIT_SECONDS]
+    df = df[df["RequestGpus"] == 1]
+    valid = len(df)
+
+    df["submitted_at"] = pd.to_datetime(df[time_col], unit="s")
+    df["wait_hours"] = df["initialwaitduration"] / 3600
+
+    capped = (df["wait_hours"] > cap_hours).sum()
+    df = df[df["wait_hours"] <= cap_hours].copy()
+    kept = len(df)
+
+    print(f"Loaded {total:,} rows total")
+    print(f"  {valid:,} single-GPU jobs with valid wait data")
+    print(f"  {capped:,} dropped as outliers (wait > {cap_hours:.0f} h, " f"{capped / valid * 100:.1f}% of valid rows)")
+    print(f"  {kept:,} kept for analysis")
+    return df
+
+
+def rolling_stats(df: pd.DataFrame, window: str) -> pd.DataFrame:
+    ts = df.set_index("submitted_at").sort_index()["wait_hours"]
+
+    # Evaluate the rolling median on a regular 30-minute grid to avoid
+    # duplicate-timestamp noise from jobs submitted at the same second.
+    grid = pd.date_range(ts.index.min().floor("30min"), ts.index.max().ceil("30min"), freq="30min")
+    rolling_median = pd.Series(index=grid, dtype=float)
+    window_td = pd.Timedelta(window)
+    for t in grid:
+        window_jobs = ts[(ts.index >= t - window_td) & (ts.index < t)]
+        if len(window_jobs) >= MIN_PERIODS:
+            rolling_median[t] = window_jobs.median()
+
+    stats = pd.DataFrame({"rolling_median": rolling_median})
+
+    # 14-day baseline: daily medians rolled forward.
+    daily = ts.resample("1D").median().dropna()
+    baseline = daily.rolling(window=BASELINE_WINDOW_DAYS, min_periods=3, center=False).median()
+    stats["baseline"] = baseline.reindex(stats.index, method="ffill")
+    stats["ratio"] = stats["rolling_median"] / stats["baseline"]
+    return stats
+
+
+def print_summary(df: pd.DataFrame, stats: pd.DataFrame, recent_days: int) -> None:
+    cutoff = df["submitted_at"].max() - pd.Timedelta(days=recent_days)
+    recent_df = df[df["submitted_at"] > cutoff]
+    hist_df = df[df["submitted_at"] <= cutoff]
+
+    print("\n" + "=" * 60)
+    print(f"Summary: recent {recent_days} days vs prior period")
+    print("=" * 60)
+    if hist_df.empty or recent_df.empty:
+        print("Not enough data to compare periods.")
+        return
+
+    for label, subset in [("Historical", hist_df), (f"Recent ({recent_days} days)", recent_df)]:
+        print(f"\n  {label}")
+        print(f"    Median wait : {subset['wait_hours'].median():.2f} h")
+        print(f"    P90 wait    : {subset['wait_hours'].quantile(0.90):.2f} h")
+        print(f"    Jobs        : {len(subset):,}")
+
+    ratio = recent_df["wait_hours"].median() / hist_df["wait_hours"].median()
+    direction = "HIGHER" if ratio > 1 else "lower"
+    print(f"\n  Median wait is {ratio:.2f}x {direction} than historical")
+
+    elevated = stats[stats["ratio"] > 2.0].dropna()
+    if not elevated.empty:
+        # Collapse consecutive elevated grid points into events separated by
+        # gaps of more than 6 hours.
+        diffs = elevated.index.to_series().diff()
+        new_event = pd.concat([pd.Series([True]), diffs.iloc[1:] > pd.Timedelta("6h")])
+        new_event.index = elevated.index
+        event_starts = elevated.index[new_event]
+        print(f"\n  Elevated periods (rolling median > 2× baseline): {len(event_starts)}")
+        for t in event_starts:
+            window_data = stats.loc[t : t + pd.Timedelta("6h")].dropna()
+            peak_ratio = window_data["ratio"].max()
+            peak_median = window_data["rolling_median"].max()
+            print(f"    {t.strftime('%Y-%m-%d %H:%M')}  " f"peak median={peak_median:.1f}h  ratio={peak_ratio:.1f}x")
+
+
+def plot(df: pd.DataFrame, stats: pd.DataFrame, window: str, anchor: str, output: str) -> None:
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(16, 9), gridspec_kw={"height_ratios": [3, 1]}, sharex=True)
+
+    ax1.plot(
+        stats.index,
+        stats["rolling_median"],
+        color="#2980b9",
+        linewidth=1.5,
+        label=f"{window} rolling median",
+    )
+    ax1.plot(
+        stats.index,
+        stats["baseline"],
+        color="#e67e22",
+        linewidth=1.8,
+        linestyle="-.",
+        label=f"{BASELINE_WINDOW_DAYS}-day rolling baseline",
+    )
+
+    elevated_mask = stats["ratio"] > 2.0
+    if elevated_mask.any():
+        ax1.scatter(
+            stats.index[elevated_mask],
+            stats.loc[elevated_mask, "rolling_median"],
+            color="#e74c3c",
+            zorder=5,
+            s=15,
+            label="Rolling median > 2× baseline",
+        )
+
+    ax1.set_ylabel("Wait duration (hours)")
+    ax1.set_title(f"InitialWaitDuration — single-GPU jobs, {window} rolling median  " f"[anchored to {anchor} time]")
+    ax1.legend(loc="upper left", fontsize=9)
+    ax1.grid(True, alpha=0.3)
+    ax1.set_ylim(bottom=0)
+
+    # Bottom panel: hourly job count
+    hourly_counts = df.set_index("submitted_at").resample("1h")["wait_hours"].count()
+    ax2.bar(hourly_counts.index, hourly_counts.values, width=1 / 24, color="#7f8c8d", alpha=0.7)
+    ax2.set_ylabel("Jobs / hour")
+    ax2.set_xlabel(ANCHOR_LABELS[anchor])
+    ax2.grid(True, alpha=0.3)
+
+    x_end = df["submitted_at"].max()
+    x_start = x_end - pd.Timedelta(days=14)
+    for ax in (ax1, ax2):
+        ax.set_xlim(x_start, x_end)
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+        ax.xaxis.set_major_locator(mdates.DayLocator(interval=1))
+        plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha="right")
+
+    plt.tight_layout()
+    plt.savefig(output, dpi=150, bbox_inches="tight")
+    print(f"\nPlot saved to {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", default="elasticsearch_dump.csv", help="Input CSV file")
+    parser.add_argument("--output", default="wait_time_trend.png", help="Output PNG file")
+    parser.add_argument(
+        "--window",
+        default=DEFAULT_WINDOW,
+        help=f"Rolling window size as a pandas offset string, e.g. 2h, 6h, 12h, 1d " f"(default: {DEFAULT_WINDOW})",
+    )
+    parser.add_argument(
+        "--cap-hours",
+        type=float,
+        default=DEFAULT_CAP_HOURS,
+        help=f"Drop jobs with wait > this many hours before analysis (default: {DEFAULT_CAP_HOURS})",
+    )
+    parser.add_argument(
+        "--recent-days",
+        type=int,
+        default=7,
+        help="Days to treat as 'recent' in the printed summary (default: 7)",
+    )
+    parser.add_argument(
+        "--anchor",
+        choices=["submit", "start"],
+        default="submit",
+        help="Time anchor: 'submit' uses QDate, 'start' uses JobCurrentStartDate (default: submit)",
+    )
+    args = parser.parse_args()
+
+    df = load_data(args.csv, cap_hours=args.cap_hours, anchor=args.anchor)
+    print(f"Date range: {df['submitted_at'].min().date()} to {df['submitted_at'].max().date()}")
+
+    stats = rolling_stats(df, window=args.window)
+    print_summary(df, stats, recent_days=args.recent_days)
+    plot(df, stats, window=args.window, anchor=args.anchor, output=args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `get_job_pressure.py`, a periodic collector that queries all HTCondor schedds every 5 minutes for idle GPU jobs (`RequestGPUs >= 1 && JobStatus == 1`) and stores per-job snapshots in `job_pressure_YYYY-MM.db`
- Captured fields: `GlobalJobId`, `ScheddName`, `Owner`, `RequestGPUs`, `RequestCPUs`, `RequestMemory`, `RequestGPUMemory` (NULL when absent), `QDate`
- Adds four new analysis/plotting scripts: `analyze_pool_health.py`, `open_cap_user_jobs.py`, `plot_wait_time_trend.py`
- `get_gpu_state.py`: adds `InitialWaitDuration` to the job_info schema and collection
- `gpu_utils_polars.py`: fixes duplicate GPU rank ordering so Primary Unclaimed (rank 2) beats Backfill Claimed (rank 1)
- `OPERATIONS.md`: documents the new cron entry, log file, and DB pattern

## Deploy

Add to crontab on the production host:
```
*/5 * * * * /home/iaross/gpureports/.venv/bin/python /home/iaross/gpureports/get_job_pressure.py &> /tmp/job_pressure.log
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)