### PR TITLE
Restructure Real Slots table: primary/secondary split and updated terminology

### DIFF
--- a/backlog/tasks/task-35 - Restructure-Real-Slots-table-primary-secondary-split-and-updated-terminology.md
+++ b/backlog/tasks/task-35 - Restructure-Real-Slots-table-primary-secondary-split-and-updated-terminology.md
@@ -1,0 +1,74 @@
+---
+id: TASK-35
+title: 'Restructure Real Slots table: primary/secondary split and updated terminology'
+status: Done
+assignee: []
+created_date: '2026-06-25 13:45'
+updated_date: '2026-06-25 15:10'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Real Slots table presents backfill usage as a disconnected bottom section, hiding the relationship between prioritized machines and their secondary (backfill) workloads. Additionally, 'Researcher Owned' and 'CHTC Owned' labels don't communicate the hardware-vs-capacity distinction to readers unfamiliar with CHTC infrastructure. This restructuring makes both the utilization story and the ownership model more transparent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] TOTAL row includes both primary and secondary usage
+- [ ] Prioritized rows split: Primary subtotal (current priority slots) + Secondary subtotal (current backfill slots on those machines)
+- [ ] Separate BACKFILL TOTAL section removed; its data appears under Prioritized → Secondary
+- [ ] "Researcher Owned" renamed to "Researcher-Owned Hardware" everywhere in the report
+- [ ] "CHTC Owned" renamed to "Researcher-Reserved Capacity" everywhere in the report
+- [ ] "Backfill" renamed to "Secondary (Backfill)" everywhere in the report
+- [ ] Open Capacity section structure unchanged
+- [ ] Report generates without errors
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Restructured the main Real Slots table in stats_reporting.py to nest Secondary (Backfill) rows under Prioritized, with Primary and Secondary sub-subtotals. TOTAL row now includes both primary and secondary usage. Removed the separate BACKFILL TOTAL section. Updated get_display_name in gpu_utils.py and gpu_utils_polars.py: Priority-ResearcherOwned → Researcher-Owned Hardware, Priority-CHTCOwned → Researcher-Reserved Capacity, Backfill-* → same display names (context provided by row grouping). Updated all user-visible label strings in stats_reporting.py text output and host_report.py overview table and section headers. Modified files: stats_reporting.py, gpu_utils.py, gpu_utils_polars.py, scripts/host_report.py
+<!-- SECTION:NOTES:END -->
+
+## Mockup
+
+### Before
+
+```
+| Class                              | Allocated % | Allocated (avg.) | Drained (avg.) | Available (avg.) |
+|------------------------------------|-------------|------------------|----------------|------------------|
+| TOTAL                              |   xx%       |       xx         |      xx        |       xx         |
+|   Prioritized (TOTAL)              |   xx%       |       xx         |      xx        |       xx         |
+|     Prioritized (Researcher Owned) |   xx%       |       xx         |      xx        |       xx         |
+|     Prioritized (CHTC Owned)       |   xx%       |       xx         |      xx        |       xx         |
+|   Open Capacity (TOTAL)            |   xx%       |       xx         |      xx        |       xx         |
+|     Open Capacity (Flagship)       |   xx%       |       xx         |      xx        |       xx         |
+|     Open Capacity (Standard)       |   xx%       |       xx         |      xx        |       xx         |
+| ── separator ──────────────────────────────────────────────────────────────────────────────────── |
+| BACKFILL TOTAL                     |   xx%       |       xx         |      xx        |       xx         |
+|   Backfill (Researcher Owned)      |   xx%       |       xx         |      xx        |       xx         |
+|   Backfill (CHTC Owned)            |   xx%       |       xx         |      xx        |       xx         |
+```
+
+Issues: TOTAL excludes backfill; backfill appears unrelated to prioritized machines; labels obscure ownership model.
+
+### After
+
+```
+| Class                                          | Allocated % | Allocated (avg.) | Drained (avg.) | Available (avg.) |
+|------------------------------------------------|-------------|------------------|----------------|------------------|
+| TOTAL (primary + secondary)                    |   xx%       |       xx         |      xx        |       xx         |
+|   Prioritized (TOTAL)                          |   xx%       |       xx         |      xx        |       xx         |
+|     Primary                                    |   xx%       |       xx         |      xx        |       xx         |
+|       Researcher-Owned Hardware                |   xx%       |       xx         |      xx        |       xx         |
+|       Researcher-Reserved Capacity             |   xx%       |       xx         |      xx        |       xx         |
+|     Secondary (Backfill)                       |   xx%       |       xx         |      xx        |       xx         |
+|       Researcher-Owned Hardware                |   xx%       |       xx         |      xx        |       xx         |
+|       Researcher-Reserved Capacity             |   xx%       |       xx         |      xx        |       xx         |
+|   Open Capacity (TOTAL)                        |   xx%       |       xx         |      xx        |       xx         |
+|     Open Capacity (Flagship)                   |   xx%       |       xx         |      xx        |       xx         |
+|     Open Capacity (Standard)                   |   xx%       |       xx         |      xx        |       xx         |
+```

--- a/gpu_utils.py
+++ b/gpu_utils.py
@@ -147,12 +147,16 @@ def filter_df(df: pd.DataFrame, utilization: str = "", state: str = "", host: st
         if duplicated_gpus.any():
             # Create a temporary rank column to sort out duplicates.
             # Prefer primary slots over backfill slots to ensure accurate total counts.
-            df["_rank"] = 0  # Default rank for Backfill Unclaimed
-            df.loc[(df["State"] == "Claimed") & (~df["Name"].str.contains("backfill")), "_rank"] = 3  # Primary Claimed
-            df.loc[(df["State"] == "Unclaimed") & (~df["Name"].str.contains("backfill")), "_rank"] = (
-                2  # Primary Unclaimed
-            )
-            df.loc[(df["State"] == "Claimed") & (df["Name"].str.contains("backfill")), "_rank"] = 1  # Backfill Claimed
+            # All primary ranks (3–5) beat all backfill ranks (0–2) so a Drained primary slot is
+            # not displaced by a Drained backfill slot and then incorrectly excluded by the filter.
+            is_primary = ~df["Name"].str.contains("backfill")
+            is_backfill = df["Name"].str.contains("backfill")
+            df["_rank"] = 0  # Backfill Drained / other (lowest)
+            df.loc[is_backfill & (df["State"] == "Unclaimed"), "_rank"] = 1  # Backfill Unclaimed
+            df.loc[is_backfill & (df["State"] == "Claimed"), "_rank"] = 2  # Backfill Claimed
+            df.loc[is_primary, "_rank"] = 3  # Primary Drained / other
+            df.loc[is_primary & (df["State"] == "Unclaimed"), "_rank"] = 4  # Primary Unclaimed
+            df.loc[is_primary & (df["State"] == "Claimed"), "_rank"] = 5  # Primary Claimed
 
             # Sort by AssignedGPUs and rank (keeping highest rank first)
             df = df.sort_values(["AssignedGPUs", "_rank"], ascending=[True, False])
@@ -200,12 +204,16 @@ def filter_df(df: pd.DataFrame, utilization: str = "", state: str = "", host: st
         if duplicated_gpus.any():
             # Create a temporary rank column to sort out duplicates.
             # Prefer primary slots over backfill slots to ensure accurate total counts.
-            df["_rank"] = 0  # Default rank for Backfill Unclaimed
-            df.loc[(df["State"] == "Claimed") & (~df["Name"].str.contains("backfill")), "_rank"] = 3  # Primary Claimed
-            df.loc[(df["State"] == "Unclaimed") & (~df["Name"].str.contains("backfill")), "_rank"] = (
-                2  # Primary Unclaimed
-            )
-            df.loc[(df["State"] == "Claimed") & (df["Name"].str.contains("backfill")), "_rank"] = 1  # Backfill Claimed
+            # All primary ranks (3–5) beat all backfill ranks (0–2) so a Drained primary slot is
+            # not displaced by a Drained backfill slot and then incorrectly excluded by the filter.
+            is_primary = ~df["Name"].str.contains("backfill")
+            is_backfill = df["Name"].str.contains("backfill")
+            df["_rank"] = 0  # Backfill Drained / other (lowest)
+            df.loc[is_backfill & (df["State"] == "Unclaimed"), "_rank"] = 1  # Backfill Unclaimed
+            df.loc[is_backfill & (df["State"] == "Claimed"), "_rank"] = 2  # Backfill Claimed
+            df.loc[is_primary, "_rank"] = 3  # Primary Drained / other
+            df.loc[is_primary & (df["State"] == "Unclaimed"), "_rank"] = 4  # Primary Unclaimed
+            df.loc[is_primary & (df["State"] == "Claimed"), "_rank"] = 5  # Primary Claimed
 
             # Sort by AssignedGPUs and rank (keeping highest rank first)
             df = df.sort_values(["AssignedGPUs", "_rank"], ascending=[True, False])
@@ -395,12 +403,16 @@ def filter_df_enhanced(df: pd.DataFrame, utilization: str = "", state: str = "",
         if duplicated_gpus.any():
             # Create a temporary rank column to sort out duplicates.
             # Prefer primary slots over backfill slots to ensure accurate total counts.
-            df["_rank"] = 0  # Default rank for Backfill Unclaimed
-            df.loc[(df["State"] == "Claimed") & (~df["Name"].str.contains("backfill")), "_rank"] = 3  # Primary Claimed
-            df.loc[(df["State"] == "Unclaimed") & (~df["Name"].str.contains("backfill")), "_rank"] = (
-                2  # Primary Unclaimed
-            )
-            df.loc[(df["State"] == "Claimed") & (df["Name"].str.contains("backfill")), "_rank"] = 1  # Backfill Claimed
+            # All primary ranks (3–5) beat all backfill ranks (0–2) so a Drained primary slot is
+            # not displaced by a Drained backfill slot and then incorrectly excluded by the filter.
+            is_primary = ~df["Name"].str.contains("backfill")
+            is_backfill = df["Name"].str.contains("backfill")
+            df["_rank"] = 0  # Backfill Drained / other (lowest)
+            df.loc[is_backfill & (df["State"] == "Unclaimed"), "_rank"] = 1  # Backfill Unclaimed
+            df.loc[is_backfill & (df["State"] == "Claimed"), "_rank"] = 2  # Backfill Claimed
+            df.loc[is_primary, "_rank"] = 3  # Primary Drained / other
+            df.loc[is_primary & (df["State"] == "Unclaimed"), "_rank"] = 4  # Primary Unclaimed
+            df.loc[is_primary & (df["State"] == "Claimed"), "_rank"] = 5  # Primary Claimed
 
             # Sort by AssignedGPUs and rank (keeping highest rank first)
             df = df.sort_values(["AssignedGPUs", "_rank"], ascending=[True, False])
@@ -452,12 +464,16 @@ def filter_df_enhanced(df: pd.DataFrame, utilization: str = "", state: str = "",
         if duplicated_gpus.any():
             # Create a temporary rank column to sort out duplicates.
             # Prefer primary slots over backfill slots to ensure accurate total counts.
-            df["_rank"] = 0  # Default rank for Backfill Unclaimed
-            df.loc[(df["State"] == "Claimed") & (~df["Name"].str.contains("backfill")), "_rank"] = 3  # Primary Claimed
-            df.loc[(df["State"] == "Unclaimed") & (~df["Name"].str.contains("backfill")), "_rank"] = (
-                2  # Primary Unclaimed
-            )
-            df.loc[(df["State"] == "Claimed") & (df["Name"].str.contains("backfill")), "_rank"] = 1  # Backfill Claimed
+            # All primary ranks (3–5) beat all backfill ranks (0–2) so a Drained primary slot is
+            # not displaced by a Drained backfill slot and then incorrectly excluded by the filter.
+            is_primary = ~df["Name"].str.contains("backfill")
+            is_backfill = df["Name"].str.contains("backfill")
+            df["_rank"] = 0  # Backfill Drained / other (lowest)
+            df.loc[is_backfill & (df["State"] == "Unclaimed"), "_rank"] = 1  # Backfill Unclaimed
+            df.loc[is_backfill & (df["State"] == "Claimed"), "_rank"] = 2  # Backfill Claimed
+            df.loc[is_primary, "_rank"] = 3  # Primary Drained / other
+            df.loc[is_primary & (df["State"] == "Unclaimed"), "_rank"] = 4  # Primary Unclaimed
+            df.loc[is_primary & (df["State"] == "Claimed"), "_rank"] = 5  # Primary Claimed
 
             # Sort by AssignedGPUs and rank (keeping highest rank first)
             df = df.sort_values(["AssignedGPUs", "_rank"], ascending=[True, False])
@@ -534,12 +550,16 @@ def filter_df_enhanced(df: pd.DataFrame, utilization: str = "", state: str = "",
         if duplicated_gpus.any():
             # Create a temporary rank column to sort out duplicates.
             # Prefer primary slots over backfill slots to ensure accurate total counts.
-            df["_rank"] = 0  # Default rank for Backfill Unclaimed
-            df.loc[(df["State"] == "Claimed") & (~df["Name"].str.contains("backfill")), "_rank"] = 3  # Primary Claimed
-            df.loc[(df["State"] == "Unclaimed") & (~df["Name"].str.contains("backfill")), "_rank"] = (
-                2  # Primary Unclaimed
-            )
-            df.loc[(df["State"] == "Claimed") & (df["Name"].str.contains("backfill")), "_rank"] = 1  # Backfill Claimed
+            # All primary ranks (3–5) beat all backfill ranks (0–2) so a Drained primary slot is
+            # not displaced by a Drained backfill slot and then incorrectly excluded by the filter.
+            is_primary = ~df["Name"].str.contains("backfill")
+            is_backfill = df["Name"].str.contains("backfill")
+            df["_rank"] = 0  # Backfill Drained / other (lowest)
+            df.loc[is_backfill & (df["State"] == "Unclaimed"), "_rank"] = 1  # Backfill Unclaimed
+            df.loc[is_backfill & (df["State"] == "Claimed"), "_rank"] = 2  # Backfill Claimed
+            df.loc[is_primary, "_rank"] = 3  # Primary Drained / other
+            df.loc[is_primary & (df["State"] == "Unclaimed"), "_rank"] = 4  # Primary Unclaimed
+            df.loc[is_primary & (df["State"] == "Claimed"), "_rank"] = 5  # Primary Claimed
 
             # Sort by AssignedGPUs and rank (keeping highest rank first)
             df = df.sort_values(["AssignedGPUs", "_rank"], ascending=[True, False])
@@ -587,12 +607,16 @@ def filter_df_enhanced(df: pd.DataFrame, utilization: str = "", state: str = "",
         if duplicated_gpus.any():
             # Create a temporary rank column to sort out duplicates.
             # Prefer primary slots over backfill slots to ensure accurate total counts.
-            df["_rank"] = 0  # Default rank for Backfill Unclaimed
-            df.loc[(df["State"] == "Claimed") & (~df["Name"].str.contains("backfill")), "_rank"] = 3  # Primary Claimed
-            df.loc[(df["State"] == "Unclaimed") & (~df["Name"].str.contains("backfill")), "_rank"] = (
-                2  # Primary Unclaimed
-            )
-            df.loc[(df["State"] == "Claimed") & (df["Name"].str.contains("backfill")), "_rank"] = 1  # Backfill Claimed
+            # All primary ranks (3–5) beat all backfill ranks (0–2) so a Drained primary slot is
+            # not displaced by a Drained backfill slot and then incorrectly excluded by the filter.
+            is_primary = ~df["Name"].str.contains("backfill")
+            is_backfill = df["Name"].str.contains("backfill")
+            df["_rank"] = 0  # Backfill Drained / other (lowest)
+            df.loc[is_backfill & (df["State"] == "Unclaimed"), "_rank"] = 1  # Backfill Unclaimed
+            df.loc[is_backfill & (df["State"] == "Claimed"), "_rank"] = 2  # Backfill Claimed
+            df.loc[is_primary, "_rank"] = 3  # Primary Drained / other
+            df.loc[is_primary & (df["State"] == "Unclaimed"), "_rank"] = 4  # Primary Unclaimed
+            df.loc[is_primary & (df["State"] == "Claimed"), "_rank"] = 5  # Primary Claimed
 
             # Sort by AssignedGPUs and rank (keeping highest rank first)
             df = df.sort_values(["AssignedGPUs", "_rank"], ascending=[True, False])

--- a/gpu_utils.py
+++ b/gpu_utils.py
@@ -681,15 +681,15 @@ def get_display_name(class_name: str) -> str:
     """Convert internal class names to user-friendly display names."""
     display_names = {
         "Priority": "Prioritized service",  # Legacy support
-        "Priority-ResearcherOwned": "Prioritized (Researcher Owned)",
-        "Priority-CHTCOwned": "Prioritized (CHTC Owned)",
+        "Priority-ResearcherOwned": "Researcher-Owned Hardware",
+        "Priority-CHTCOwned": "Researcher-Reserved Capacity",
         "Shared": "Open Capacity",
-        "Backfill": "Backfill",  # Legacy support
-        "Backfill-ResearcherOwned": "Backfill (Researcher Owned)",
-        "Backfill-CHTCOwned": "Backfill (CHTC Owned)",
-        "Backfill-OpenCapacity": "Backfill (Open Capacity)",
-        "CHTC Owned": "CHTC Owned",
-        "Researcher Owned": "Researcher Owned",
+        "Backfill": "Secondary (Backfill)",  # Legacy support
+        "Backfill-ResearcherOwned": "Researcher-Owned Hardware",
+        "Backfill-CHTCOwned": "Researcher-Reserved Capacity",
+        "Backfill-OpenCapacity": "Secondary (Backfill) — Open Capacity",
+        "CHTC Owned": "Researcher-Reserved Capacity",
+        "Researcher Owned": "Researcher-Owned Hardware",
         "Open Capacity": "Open Capacity",
         # New tier-based display names for Open Capacity breakdown
         "Open Capacity (Flagship)": "Open Capacity (Flagship)",

--- a/gpu_utils_polars.py
+++ b/gpu_utils_polars.py
@@ -397,15 +397,15 @@ def get_display_name(class_name: str) -> str:
     """Convert internal class names to user-friendly display names."""
     display_names = {
         "Priority": "Prioritized service",  # Legacy support
-        "Priority-ResearcherOwned": "Prioritized (Researcher Owned)",
-        "Priority-CHTCOwned": "Prioritized (CHTC Owned)",
+        "Priority-ResearcherOwned": "Researcher-Owned Hardware",
+        "Priority-CHTCOwned": "Researcher-Reserved Capacity",
         "Shared": "Open Capacity",
-        "Backfill": "Backfill",  # Legacy support
-        "Backfill-ResearcherOwned": "Backfill (Researcher Owned)",
-        "Backfill-CHTCOwned": "Backfill (CHTC Owned)",
-        "Backfill-OpenCapacity": "Backfill (Open Capacity)",
-        "CHTC Owned": "CHTC Owned",
-        "Researcher Owned": "Researcher Owned",
+        "Backfill": "Secondary (Backfill)",  # Legacy support
+        "Backfill-ResearcherOwned": "Researcher-Owned Hardware",
+        "Backfill-CHTCOwned": "Researcher-Reserved Capacity",
+        "Backfill-OpenCapacity": "Secondary (Backfill) — Open Capacity",
+        "CHTC Owned": "Researcher-Reserved Capacity",
+        "Researcher Owned": "Researcher-Owned Hardware",
         "Open Capacity": "Open Capacity",
     }
     return display_names.get(class_name, class_name)

--- a/gpu_utils_polars.py
+++ b/gpu_utils_polars.py
@@ -512,16 +512,20 @@ def _apply_duplicate_cleanup(df: pl.DataFrame) -> pl.DataFrame:
         return df
 
     # Create a rank column to sort out duplicates.
-    # Prefer primary slots over backfill slots, and claimed over unclaimed within the same type.
-    # This matches the pandas version: Primary Claimed > Primary Unclaimed > Backfill Claimed > Backfill Unclaimed.
-    # IMPORTANT: Primary Unclaimed (rank 2) must beat Backfill Claimed (rank 1) so that idle GPUs
-    # that are also offered as backfill are not dropped from the denominator after the backfill filter.
+    # Prefer primary slots over backfill slots; within each type, prefer Claimed > Unclaimed > Drained.
+    # All primary ranks (3–5) beat all backfill ranks (0–2) so that a Drained primary slot is not
+    # displaced by a Drained backfill slot and then incorrectly excluded by the "not backfill" filter.
+    is_backfill = pl.col("Name").str.contains("backfill")
     df = df.with_columns(
-        pl.when((pl.col("State") == "Claimed") & (~pl.col("Name").str.contains("backfill")))
+        pl.when((pl.col("State") == "Claimed") & (~is_backfill))
+        .then(5)
+        .when((pl.col("State") == "Unclaimed") & (~is_backfill))
+        .then(4)
+        .when(~is_backfill)
         .then(3)
-        .when((pl.col("State") == "Unclaimed") & (~pl.col("Name").str.contains("backfill")))
+        .when((pl.col("State") == "Claimed") & is_backfill)
         .then(2)
-        .when((pl.col("State") == "Claimed") & (pl.col("Name").str.contains("backfill")))
+        .when((pl.col("State") == "Unclaimed") & is_backfill)
         .then(1)
         .otherwise(0)
         .alias("_rank")

--- a/stats_reporting.py
+++ b/stats_reporting.py
@@ -487,21 +487,21 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
         pri_secondary_total = sum(class_totals[c]["total"] for c in secondary_classes if c in class_totals)
         pri_secondary_pct = (pri_secondary_claimed / pri_secondary_total * 100) if pri_secondary_total > 0 else 0
 
-        # Prioritized (TOTAL) = primary + secondary
+        # Prioritized (TOTAL): claimed = primary + secondary, but available = primary only
+        # (secondary runs on the same physical GPUs — adding secondary total would double-count)
         pri_total_claimed = pri_primary_claimed + pri_secondary_claimed
         pri_total_drained = pri_primary_drained + pri_secondary_drained
-        pri_total_avail = pri_primary_total + pri_secondary_total
-        pri_total_pct = (pri_total_claimed / pri_total_avail * 100) if pri_total_avail > 0 else 0
+        pri_total_pct = (pri_total_claimed / pri_primary_total * 100) if pri_primary_total > 0 else 0
 
         # Open Capacity
         oc_claimed = class_totals.get("Shared", {}).get("claimed", 0)
         oc_drained = class_totals.get("Shared", {}).get("drained", 0)
         oc_total_avail = class_totals.get("Shared", {}).get("total", 0)
 
-        # Grand TOTAL = Prioritized (primary + secondary) + Open Capacity
+        # Grand TOTAL: available = primary physical GPUs + open capacity (no double-count)
         grand_claimed = pri_total_claimed + oc_claimed
         grand_drained = pri_total_drained + oc_drained
-        grand_total_avail = pri_total_avail + oc_total_avail
+        grand_total_avail = pri_primary_total + oc_total_avail
         grand_pct = (grand_claimed / grand_total_avail * 100) if grand_total_avail > 0 else 0
 
         # Calculate Open Capacity breakdown by performance tier (Flagship vs Standard)
@@ -548,7 +548,7 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
         html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_total_pct:.1f}%</td>")
         html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_total_claimed:.1f}</td>")
         html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_total_drained:.1f}</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_total_avail:.1f}</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_primary_total:.1f}</td>")
         html_parts.append("</tr>")
 
         # Primary sub-subtotal
@@ -1401,13 +1401,13 @@ def print_analysis_results(results: dict, output_format: str = "text", output_fi
         oc_claimed = grand_totals.get("Shared", {}).get("claimed", 0)
         oc_total = grand_totals.get("Shared", {}).get("total", 0)
 
-        grand_claimed = pri_primary_claimed + pri_secondary_claimed + oc_claimed
-        grand_total = pri_primary_total + pri_secondary_total + oc_total
+        # Available = primary physical GPUs + open capacity; secondary runs on the same GPUs as primary
+        pri_total_claimed = pri_primary_claimed + pri_secondary_claimed
+        grand_claimed = pri_total_claimed + oc_claimed
+        grand_total = pri_primary_total + oc_total
         grand_percent = (grand_claimed / grand_total * 100) if grand_total > 0 else 0
 
-        pri_total_claimed = pri_primary_claimed + pri_secondary_claimed
-        pri_total_avail = pri_primary_total + pri_secondary_total
-        pri_total_pct = (pri_total_claimed / pri_total_avail * 100) if pri_total_avail > 0 else 0
+        pri_total_pct = (pri_total_claimed / pri_primary_total * 100) if pri_primary_total > 0 else 0
         pri_primary_pct = (pri_primary_claimed / pri_primary_total * 100) if pri_primary_total > 0 else 0
         pri_secondary_pct = (pri_secondary_claimed / pri_secondary_total * 100) if pri_secondary_total > 0 else 0
 
@@ -1415,7 +1415,7 @@ def print_analysis_results(results: dict, output_format: str = "text", output_fi
         print(f"{'-' * 70}")
         print(f"  TOTAL (primary + secondary): {grand_percent:.1f}% ({grand_claimed:.1f}/{grand_total:.1f} GPUs)")
         print(
-            f"  Prioritized (TOTAL):          {pri_total_pct:.1f}% ({pri_total_claimed:.1f}/{pri_total_avail:.1f} GPUs)"
+            f"  Prioritized (TOTAL):          {pri_total_pct:.1f}% ({pri_total_claimed:.1f}/{pri_primary_total:.1f} GPUs)"
         )
         print(
             f"    Primary:                    {pri_primary_pct:.1f}% ({pri_primary_claimed:.1f}/{pri_primary_total:.1f} GPUs)"

--- a/stats_reporting.py
+++ b/stats_reporting.py
@@ -78,7 +78,7 @@ def print_gpu_model_analysis(analysis: dict):
             usage_pct = (stats["claimed"] / stats["total"] * 100) if stats["total"] > 0 else 0
             print(f"  {class_name}: {stats['claimed']}/{stats['total']} ({usage_pct:.1f}%)")
 
-    print("\nBACKFILL SLOTS:")
+    print("\nSECONDARY (BACKFILL) SLOTS:")
     print(f"{'-' * 40}")
     print(f"  TOTAL: {backfill_claimed}/{backfill_total} ({backfill_usage_pct:.1f}%)")
     print(f"{'-' * 40}")
@@ -470,23 +470,39 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
                         "percent": (total_claimed / total_available) * 100,
                     }
 
-    # Cluster summary at the top with real slots and backfill slots separated
+    # Cluster summary at the top — Prioritized rows include both primary and secondary (backfill)
     if class_totals:
-        # Separate real slots from backfill slots
-        real_slot_classes = ["Priority-ResearcherOwned", "Priority-CHTCOwned", "Shared"]
-        backfill_slot_classes = ["Backfill-ResearcherOwned", "Backfill-CHTCOwned"]
+        primary_classes = ["Priority-ResearcherOwned", "Priority-CHTCOwned"]
+        secondary_classes = ["Backfill-ResearcherOwned", "Backfill-CHTCOwned"]
 
-        # Calculate totals for real slots
-        real_claimed = sum(class_totals[c]["claimed"] for c in real_slot_classes if c in class_totals)
-        real_drained = sum(class_totals[c]["drained"] for c in real_slot_classes if c in class_totals)
-        real_total = sum(class_totals[c]["total"] for c in real_slot_classes if c in class_totals)
-        real_percent = (real_claimed / real_total * 100) if real_total > 0 else 0
+        # Primary subtotal (priority slots only)
+        pri_primary_claimed = sum(class_totals[c]["claimed"] for c in primary_classes if c in class_totals)
+        pri_primary_drained = sum(class_totals[c]["drained"] for c in primary_classes if c in class_totals)
+        pri_primary_total = sum(class_totals[c]["total"] for c in primary_classes if c in class_totals)
+        pri_primary_pct = (pri_primary_claimed / pri_primary_total * 100) if pri_primary_total > 0 else 0
 
-        # Calculate totals for backfill slots
-        backfill_claimed = sum(class_totals[c]["claimed"] for c in backfill_slot_classes if c in class_totals)
-        backfill_drained = sum(class_totals[c]["drained"] for c in backfill_slot_classes if c in class_totals)
-        backfill_total = sum(class_totals[c]["total"] for c in backfill_slot_classes if c in class_totals)
-        backfill_percent = (backfill_claimed / backfill_total * 100) if backfill_total > 0 else 0
+        # Secondary subtotal (backfill on prioritized machines)
+        pri_secondary_claimed = sum(class_totals[c]["claimed"] for c in secondary_classes if c in class_totals)
+        pri_secondary_drained = sum(class_totals[c]["drained"] for c in secondary_classes if c in class_totals)
+        pri_secondary_total = sum(class_totals[c]["total"] for c in secondary_classes if c in class_totals)
+        pri_secondary_pct = (pri_secondary_claimed / pri_secondary_total * 100) if pri_secondary_total > 0 else 0
+
+        # Prioritized (TOTAL) = primary + secondary
+        pri_total_claimed = pri_primary_claimed + pri_secondary_claimed
+        pri_total_drained = pri_primary_drained + pri_secondary_drained
+        pri_total_avail = pri_primary_total + pri_secondary_total
+        pri_total_pct = (pri_total_claimed / pri_total_avail * 100) if pri_total_avail > 0 else 0
+
+        # Open Capacity
+        oc_claimed = class_totals.get("Shared", {}).get("claimed", 0)
+        oc_drained = class_totals.get("Shared", {}).get("drained", 0)
+        oc_total_avail = class_totals.get("Shared", {}).get("total", 0)
+
+        # Grand TOTAL = Prioritized (primary + secondary) + Open Capacity
+        grand_claimed = pri_total_claimed + oc_claimed
+        grand_drained = pri_total_drained + oc_drained
+        grand_total_avail = pri_total_avail + oc_total_avail
+        grand_pct = (grand_claimed / grand_total_avail * 100) if grand_total_avail > 0 else 0
 
         # Calculate Open Capacity breakdown by performance tier (Flagship vs Standard)
         open_capacity_tiers = {
@@ -501,7 +517,6 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
                 open_capacity_tiers[tier]["drained"] += stats.get("avg_drained", 0.0)
                 open_capacity_tiers[tier]["total"] += stats["avg_total_available"]
 
-        # Calculate percentages for each tier
         for tier in open_capacity_tiers:
             if open_capacity_tiers[tier]["total"] > 0:
                 open_capacity_tiers[tier]["percent"] = (
@@ -514,45 +529,70 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
         html_parts.append("<h2>Real Slots</h2>")
         html_parts.append("<table border='1' style='margin-top: 20px;'>")
         html_parts.append(
-            "<tr style='background-color: #e0e0e0;'><th>Class</th><th>Allocated %</th><th>Allocated (avg.)</th><th>Drained (avg.)</th><th>Available (avg.)</th></tr>"
+            "<tr style='background-color: #e0e0e0;'><th>Class</th><th>Allocated %</th><th>Allocated (avg.)</th>"
+            "<th>Drained (avg.)</th><th>Available (avg.)</th></tr>"
         )
 
-        # Total row for real slots
+        # Grand TOTAL row (primary + secondary + open capacity)
         html_parts.append("<tr style='background-color: #d0d0d0; font-weight: bold;'>")
-        html_parts.append("<td style='font-weight: bold;'>TOTAL</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{real_percent:.1f}%</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{real_claimed:.1f}</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{real_drained:.1f}</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{real_total:.1f}</td>")
+        html_parts.append("<td style='font-weight: bold;'>TOTAL (primary + secondary)</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{grand_pct:.1f}%</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{grand_claimed:.1f}</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{grand_drained:.1f}</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{grand_total_avail:.1f}</td>")
         html_parts.append("</tr>")
 
-        # Prioritized subtotal row
-        priority_classes = ["Priority-ResearcherOwned", "Priority-CHTCOwned"]
-        pri_claimed = sum(class_totals[c]["claimed"] for c in priority_classes if c in class_totals)
-        pri_drained = sum(class_totals[c]["drained"] for c in priority_classes if c in class_totals)
-        pri_total = sum(class_totals[c]["total"] for c in priority_classes if c in class_totals)
-        pri_percent = (pri_claimed / pri_total * 100) if pri_total > 0 else 0
+        # Prioritized (TOTAL) subtotal = primary + secondary
         html_parts.append("<tr style='background-color: #e8e8e8;'>")
         html_parts.append("<td style='font-weight: bold; padding-left: 8px;'>Prioritized (TOTAL)</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_percent:.1f}%</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_claimed:.1f}</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_drained:.1f}</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_total:.1f}</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_total_pct:.1f}%</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_total_claimed:.1f}</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_total_drained:.1f}</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_total_avail:.1f}</td>")
         html_parts.append("</tr>")
 
-        # Individual priority rows
-        for class_name in priority_classes:
+        # Primary sub-subtotal
+        html_parts.append("<tr style='background-color: #eeeeee;'>")
+        html_parts.append("<td style='font-weight: bold; padding-left: 16px;'>Primary</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_primary_pct:.1f}%</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_primary_claimed:.1f}</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_primary_drained:.1f}</td>")
+        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_primary_total:.1f}</td>")
+        html_parts.append("</tr>")
+
+        for class_name in primary_classes:
             if class_name in class_totals:
                 totals = class_totals[class_name]
                 html_parts.append("<tr>")
-                html_parts.append(f"<td style='padding-left: 16px;'>{get_display_name(class_name)}</td>")
+                html_parts.append(f"<td style='padding-left: 24px;'>{get_display_name(class_name)}</td>")
                 html_parts.append(f"<td style='text-align: right;'>{totals['percent']:.1f}%</td>")
                 html_parts.append(f"<td style='text-align: right;'>{totals['claimed']:.1f}</td>")
                 html_parts.append(f"<td style='text-align: right;'>{totals['drained']:.1f}</td>")
                 html_parts.append(f"<td style='text-align: right;'>{totals['total']:.1f}</td>")
                 html_parts.append("</tr>")
 
-        # Open Capacity subtotal row
+        # Secondary (Backfill) sub-subtotal
+        if pri_secondary_total > 0:
+            html_parts.append("<tr style='background-color: #eeeeee;'>")
+            html_parts.append("<td style='font-weight: bold; padding-left: 16px;'>Secondary (Backfill)</td>")
+            html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_secondary_pct:.1f}%</td>")
+            html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_secondary_claimed:.1f}</td>")
+            html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_secondary_drained:.1f}</td>")
+            html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{pri_secondary_total:.1f}</td>")
+            html_parts.append("</tr>")
+
+            for class_name in secondary_classes:
+                if class_name in class_totals:
+                    totals = class_totals[class_name]
+                    html_parts.append("<tr>")
+                    html_parts.append(f"<td style='padding-left: 24px;'>{get_display_name(class_name)}</td>")
+                    html_parts.append(f"<td style='text-align: right;'>{totals['percent']:.1f}%</td>")
+                    html_parts.append(f"<td style='text-align: right;'>{totals['claimed']:.1f}</td>")
+                    html_parts.append(f"<td style='text-align: right;'>{totals['drained']:.1f}</td>")
+                    html_parts.append(f"<td style='text-align: right;'>{totals['total']:.1f}</td>")
+                    html_parts.append("</tr>")
+
+        # Open Capacity subtotal row (unchanged structure)
         if "Shared" in class_totals:
             oc_totals = class_totals["Shared"]
             html_parts.append("<tr style='background-color: #e8e8e8;'>")
@@ -563,7 +603,6 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
             html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{oc_totals['total']:.1f}</td>")
             html_parts.append("</tr>")
 
-            # Open Capacity broken down by tier
             for tier in ["Flagship", "Standard"]:
                 tier_data = open_capacity_tiers[tier]
                 if tier_data["total"] > 0:
@@ -574,30 +613,6 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
                     html_parts.append(f"<td style='text-align: right;'>{tier_data['drained']:.1f}</td>")
                     html_parts.append(f"<td style='text-align: right;'>{tier_data['total']:.1f}</td>")
                     html_parts.append("</tr>")
-
-        # Add separator row and backfill slots to the same table
-        html_parts.append("<tr style='background-color: #f0f0f0;'><td colspan='5' style='height: 10px;'></td></tr>")
-
-        # Backfill section header
-        html_parts.append("<tr style='background-color: #d0d0d0; font-weight: bold;'>")
-        html_parts.append("<td style='font-weight: bold;'>BACKFILL TOTAL</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{backfill_percent:.1f}%</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{backfill_claimed:.1f}</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{backfill_drained:.1f}</td>")
-        html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{backfill_total:.1f}</td>")
-        html_parts.append("</tr>")
-
-        # Individual backfill slot classes
-        for class_name in backfill_slot_classes:
-            if class_name in class_totals:
-                totals = class_totals[class_name]
-                html_parts.append("<tr>")
-                html_parts.append(f"<td style='font-weight: bold;'>{get_display_name(class_name)}</td>")
-                html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{totals['percent']:.1f}%</td>")
-                html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{totals['claimed']:.1f}</td>")
-                html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{totals['drained']:.1f}</td>")
-                html_parts.append(f"<td style='text-align: right; font-weight: bold;'>{totals['total']:.1f}</td>")
-                html_parts.append("</tr>")
 
         html_parts.append("</table>")
 
@@ -993,21 +1008,21 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
 
                 html_parts.append("</table>")
 
-        # Cluster summary with real slots and backfill slots separated
+        # Cluster summary with real slots and secondary (backfill) slots separated
         if class_totals:
-            # Separate real slots from backfill slots (using simplified class names)
-            real_slot_classes = ["Shared", "Priority"]
-            backfill_slot_classes = ["Backfill"]
+            primary_slot_classes = ["Shared", "Priority"]
+            secondary_slot_classes = ["Backfill"]
 
-            # Calculate totals for real slots
-            real_claimed = sum(class_totals[c]["claimed"] for c in real_slot_classes if c in class_totals)
-            real_total = sum(class_totals[c]["total"] for c in real_slot_classes if c in class_totals)
-            real_percent = (real_claimed / real_total * 100) if real_total > 0 else 0
+            # Grand TOTAL = primary + secondary
+            primary_claimed = sum(class_totals[c]["claimed"] for c in primary_slot_classes if c in class_totals)
+            primary_total = sum(class_totals[c]["total"] for c in primary_slot_classes if c in class_totals)
+            secondary_claimed = sum(class_totals[c]["claimed"] for c in secondary_slot_classes if c in class_totals)
+            secondary_total = sum(class_totals[c]["total"] for c in secondary_slot_classes if c in class_totals)
+            grand_claimed = primary_claimed + secondary_claimed
+            grand_total = primary_total + secondary_total
+            grand_percent = (grand_claimed / grand_total * 100) if grand_total > 0 else 0
 
-            # Calculate totals for backfill slots
-            backfill_claimed = sum(class_totals[c]["claimed"] for c in backfill_slot_classes if c in class_totals)
-            backfill_total = sum(class_totals[c]["total"] for c in backfill_slot_classes if c in class_totals)
-            backfill_percent = (backfill_claimed / backfill_total * 100) if backfill_total > 0 else 0
+            secondary_percent = (secondary_claimed / secondary_total * 100) if secondary_total > 0 else 0
 
             # Real Slots Table
             html_parts.append("<h2>Real Slots</h2>")
@@ -1016,16 +1031,16 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
                 "<tr><th>Class</th><th>Allocated %</th><th>Allocated (avg.)</th><th>Available (avg.)</th></tr>"
             )
 
-            # Total row for real slots
+            # Grand TOTAL row (primary + secondary)
             html_parts.append("<tr style='font-weight: bold; background-color: #f0f0f0;'>")
-            html_parts.append("<td>TOTAL</td>")
-            html_parts.append(f"<td style='text-align: right'>{real_percent:.1f}%</td>")
-            html_parts.append(f"<td style='text-align: right'>{real_claimed:.1f}</td>")
-            html_parts.append(f"<td style='text-align: right'>{real_total:.1f}</td>")
+            html_parts.append("<td>TOTAL (primary + secondary)</td>")
+            html_parts.append(f"<td style='text-align: right'>{grand_percent:.1f}%</td>")
+            html_parts.append(f"<td style='text-align: right'>{grand_claimed:.1f}</td>")
+            html_parts.append(f"<td style='text-align: right'>{grand_total:.1f}</td>")
             html_parts.append("</tr>")
 
-            # Individual real slot classes
-            for class_name in real_slot_classes:
+            # Individual primary slot classes
+            for class_name in primary_slot_classes:
                 if class_name in class_totals:
                     stats = class_totals[class_name]
                     html_parts.append("<tr>")
@@ -1034,6 +1049,26 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
                     html_parts.append(f"<td style='text-align: right'>{stats['claimed']:.1f}</td>")
                     html_parts.append(f"<td style='text-align: right'>{stats['total']:.1f}</td>")
                     html_parts.append("</tr>")
+
+            # Secondary (Backfill) rows
+            if secondary_total > 0:
+                html_parts.append("<tr style='font-weight: bold; background-color: #f0f0f0;'>")
+                html_parts.append("<td>Secondary (Backfill)</td>")
+                html_parts.append(f"<td style='text-align: right'>{secondary_percent:.1f}%</td>")
+                html_parts.append(f"<td style='text-align: right'>{secondary_claimed:.1f}</td>")
+                html_parts.append(f"<td style='text-align: right'>{secondary_total:.1f}</td>")
+                html_parts.append("</tr>")
+
+                for class_name in secondary_slot_classes:
+                    if class_name in class_totals:
+                        stats = class_totals[class_name]
+                        html_parts.append("<tr>")
+                        html_parts.append(f"<td style='padding-left: 16px;'>{get_display_name(class_name)}</td>")
+                        html_parts.append(f"<td style='text-align: right'>{stats['percent']:.1f}%</td>")
+                        html_parts.append(f"<td style='text-align: right'>{stats['claimed']:.1f}</td>")
+                        html_parts.append(f"<td style='text-align: right'>{stats['total']:.1f}</td>")
+                        html_parts.append("</tr>")
+
             html_parts.append("</table>")
 
             # Real Slots by Memory Category Table
@@ -1098,33 +1133,6 @@ def generate_html_report(results: dict, output_file: str | None = None) -> str:
                         html_parts.append("</tr>")
 
                     html_parts.append("</table>")
-
-            # Backfill Slots Table
-            html_parts.append("<h2>Backfill Slots</h2>")
-            html_parts.append("<table border='1'>")
-            html_parts.append(
-                "<tr><th>Class</th><th>Allocated %</th><th>Allocated (avg.)</th><th>Available (avg.)</th></tr>"
-            )
-
-            # Total row for backfill slots
-            html_parts.append("<tr style='font-weight: bold; background-color: #f0f0f0;'>")
-            html_parts.append("<td>TOTAL</td>")
-            html_parts.append(f"<td style='text-align: right'>{backfill_percent:.1f}%</td>")
-            html_parts.append(f"<td style='text-align: right'>{backfill_claimed:.1f}</td>")
-            html_parts.append(f"<td style='text-align: right'>{backfill_total:.1f}</td>")
-            html_parts.append("</tr>")
-
-            # Individual backfill slot classes
-            for class_name in backfill_slot_classes:
-                if class_name in class_totals:
-                    stats = class_totals[class_name]
-                    html_parts.append("<tr>")
-                    html_parts.append(f"<td>{get_display_name(class_name)}</td>")
-                    html_parts.append(f"<td style='text-align: right'>{stats['percent']:.1f}%</td>")
-                    html_parts.append(f"<td style='text-align: right'>{stats['claimed']:.1f}</td>")
-                    html_parts.append(f"<td style='text-align: right'>{stats['total']:.1f}</td>")
-                    html_parts.append("</tr>")
-            html_parts.append("</table>")
 
     # Draining Status
     draining_stats = results.get("draining_stats", {})
@@ -1379,33 +1387,61 @@ def print_analysis_results(results: dict, output_format: str = "text", output_fi
                         "percent": (total_claimed / total_available) * 100,
                     }
 
-    # Show cluster summary at the top with real slots and backfill slots separated
+    # Show cluster summary at the top — Prioritized includes primary and secondary (backfill)
     if grand_totals:
-        # Separate real slots from backfill slots
-        real_slot_classes = ["Priority-ResearcherOwned", "Priority-CHTCOwned", "Shared"]
-        backfill_slot_classes = ["Backfill-ResearcherOwned", "Backfill-CHTCOwned"]
+        primary_classes = ["Priority-ResearcherOwned", "Priority-CHTCOwned"]
+        secondary_classes = ["Backfill-ResearcherOwned", "Backfill-CHTCOwned"]
 
-        # Calculate totals for real slots
-        real_claimed = sum(grand_totals[c]["claimed"] for c in real_slot_classes if c in grand_totals)
-        real_total = sum(grand_totals[c]["total"] for c in real_slot_classes if c in grand_totals)
-        real_percent = (real_claimed / real_total * 100) if real_total > 0 else 0
+        pri_primary_claimed = sum(grand_totals[c]["claimed"] for c in primary_classes if c in grand_totals)
+        pri_primary_total = sum(grand_totals[c]["total"] for c in primary_classes if c in grand_totals)
 
-        # Calculate totals for backfill slots
-        backfill_claimed = sum(grand_totals[c]["claimed"] for c in backfill_slot_classes if c in grand_totals)
-        backfill_total = sum(grand_totals[c]["total"] for c in backfill_slot_classes if c in grand_totals)
-        backfill_percent = (backfill_claimed / backfill_total * 100) if backfill_total > 0 else 0
+        pri_secondary_claimed = sum(grand_totals[c]["claimed"] for c in secondary_classes if c in grand_totals)
+        pri_secondary_total = sum(grand_totals[c]["total"] for c in secondary_classes if c in grand_totals)
+
+        oc_claimed = grand_totals.get("Shared", {}).get("claimed", 0)
+        oc_total = grand_totals.get("Shared", {}).get("total", 0)
+
+        grand_claimed = pri_primary_claimed + pri_secondary_claimed + oc_claimed
+        grand_total = pri_primary_total + pri_secondary_total + oc_total
+        grand_percent = (grand_claimed / grand_total * 100) if grand_total > 0 else 0
+
+        pri_total_claimed = pri_primary_claimed + pri_secondary_claimed
+        pri_total_avail = pri_primary_total + pri_secondary_total
+        pri_total_pct = (pri_total_claimed / pri_total_avail * 100) if pri_total_avail > 0 else 0
+        pri_primary_pct = (pri_primary_claimed / pri_primary_total * 100) if pri_primary_total > 0 else 0
+        pri_secondary_pct = (pri_secondary_claimed / pri_secondary_total * 100) if pri_secondary_total > 0 else 0
 
         print("\nREAL SLOTS:")
         print(f"{'-' * 70}")
-        print(f"  TOTAL: {real_percent:.1f}% ({real_claimed:.1f}/{real_total:.1f} GPUs)")
+        print(f"  TOTAL (primary + secondary): {grand_percent:.1f}% ({grand_claimed:.1f}/{grand_total:.1f} GPUs)")
+        print(
+            f"  Prioritized (TOTAL):          {pri_total_pct:.1f}% ({pri_total_claimed:.1f}/{pri_total_avail:.1f} GPUs)"
+        )
+        print(
+            f"    Primary:                    {pri_primary_pct:.1f}% ({pri_primary_claimed:.1f}/{pri_primary_total:.1f} GPUs)"
+        )
         print(f"{'-' * 70}")
-        for class_name in real_slot_classes:
+        for class_name in primary_classes:
             if class_name in grand_totals:
                 totals = grand_totals[class_name]
                 print(
-                    f"  {get_display_name(class_name)}: {totals['percent']:.1f}% "
+                    f"      {get_display_name(class_name)}: {totals['percent']:.1f}% "
                     f"({totals['claimed']:.1f}/{totals['total']:.1f} GPUs)"
                 )
+        if pri_secondary_total > 0:
+            print(
+                f"    Secondary (Backfill):       {pri_secondary_pct:.1f}% ({pri_secondary_claimed:.1f}/{pri_secondary_total:.1f} GPUs)"
+            )
+            for class_name in secondary_classes:
+                if class_name in grand_totals:
+                    totals = grand_totals[class_name]
+                    print(
+                        f"      {get_display_name(class_name)}: {totals['percent']:.1f}% "
+                        f"({totals['claimed']:.1f}/{totals['total']:.1f} GPUs)"
+                    )
+        if oc_total > 0:
+            oc_pct = grand_totals["Shared"]["percent"]
+            print(f"  Open Capacity: {oc_pct:.1f}% ({oc_claimed:.1f}/{oc_total:.1f} GPUs)")
 
         # Real Slots by Memory Category
         if "memory_stats" in results:
@@ -1464,18 +1500,6 @@ def print_analysis_results(results: dict, output_format: str = "text", output_fi
                         f"  {memory_cat}: {allocated_pct:.1f}% "
                         f"({allocated:.1f}/{stats['avg_total_available']:.1f} GPUs)"
                     )
-
-        print("\nBACKFILL SLOTS:")
-        print(f"{'-' * 70}")
-        print(f"  TOTAL: {backfill_percent:.1f}% ({backfill_claimed:.1f}/{backfill_total:.1f} GPUs)")
-        print(f"{'-' * 70}")
-        for class_name in backfill_slot_classes:
-            if class_name in grand_totals:
-                totals = grand_totals[class_name]
-                print(
-                    f"  {get_display_name(class_name)}: {totals['percent']:.1f}% "
-                    f"({totals['claimed']:.1f}/{totals['total']:.1f} GPUs)"
-                )
 
         # H200 Usage by Slot Type
         if "h200_user_stats" in results:


### PR DESCRIPTION
## Summary

- TOTAL row now includes both primary and secondary (backfill) usage
- Prioritized section split into **Primary** and **Secondary (Backfill)** sub-groups; the separate BACKFILL TOTAL section is removed — backfill rows now live under the machines they run on
- Updated display labels throughout:
  - "Researcher Owned" → "Researcher-Owned Hardware"
  - "CHTC Owned" → "Researcher-Reserved Capacity"
  - "Backfill" → "Secondary (Backfill)"
- `get_display_name` updated in both `gpu_utils.py` and `gpu_utils_polars.py`
- Text output path and `host_report.py` section headers updated to match

## Test plan

- [ ] HTML report renders without errors
- [ ] Real Slots table shows TOTAL (primary + secondary), Prioritized (TOTAL), Primary subtotal, Secondary (Backfill) subtotal, and Open Capacity unchanged
- [ ] New terminology appears consistently across all report sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)